### PR TITLE
Import stylable types from runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "sinon": "^3.2.1",
     "sinon-chai": "^2.13.0",
     "source-map-support": "^0.4.16",
-    "stylable": "^4.0.3",
+    "stylable": "^4.0.16",
     "test-drive-react": "^0.7.0",
     "typescript": "~2.5.2",
     "typings-checker": "^2.0.0",

--- a/src/react-component-features/stylable-feature.ts
+++ b/src/react-component-features/stylable-feature.ts
@@ -1,4 +1,4 @@
-import {RuntimeStylesheet, Stylesheet} from "stylable";
+import {RuntimeStylesheet, Stylesheet} from "stylable/runtime";
 import {decorateReactComponent} from "../react-decor/index";
 import {ElementArgs, StatelessElementHook} from "../react-decor/common";
 

--- a/test/react-component-features/properties-and-stylable.spec.tsx
+++ b/test/react-component-features/properties-and-stylable.spec.tsx
@@ -1,5 +1,5 @@
 import {properties, stylable} from "../../src";
-import {createGenerator} from "stylable";
+import {createGenerator} from "stylable/dist/src/generator";
 import {ClientRenderer, expect} from "test-drive-react";
 import * as React from "react";
 import {inBrowser} from "mocha-plugin-env";

--- a/test/react-component-features/stylable-feature.spec.tsx
+++ b/test/react-component-features/stylable-feature.spec.tsx
@@ -1,5 +1,5 @@
 import {stylable} from "../../src";
-import {createGenerator} from "stylable";
+import {createGenerator} from "stylable/dist/src/generator";
 import {ClientRenderer, expect} from "test-drive-react";
 import * as React from "react";
 import {inBrowser} from "mocha-plugin-env";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,7 +1238,7 @@ engine.io@1.8.3:
     engine.io-parser "1.3.2"
     ws "1.1.2"
 
-enhanced-resolve@^3.4.0:
+enhanced-resolve@^3.4.0, enhanced-resolve@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
   dependencies:
@@ -2240,10 +2240,6 @@ karma@^1.7.0:
     tmp "0.0.31"
     useragent "^2.1.12"
 
-kebab-case@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/kebab-case/-/kebab-case-1.0.0.tgz#3f9e4990adcad0c686c0e701f7645868f75f91eb"
-
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2665,7 +2661,7 @@ multicast-dns@^6.0.1:
     dns-packet "^1.0.1"
     thunky "^0.1.0"
 
-murmurhash@0.0.2:
+murmurhash@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/murmurhash/-/murmurhash-0.0.2.tgz#6f07bd8a1105e709c26fc89420cb5930c24585fe"
 
@@ -4075,32 +4071,26 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-stylable@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/stylable/-/stylable-4.0.4.tgz#9bb3bef02c76ea4b06cf74f36878d231e8998186"
+stylable@^4.0.16:
+  version "4.0.16"
+  resolved "https://registry.yarnpkg.com/stylable/-/stylable-4.0.16.tgz#175381de0f2a5a2b59a6a74aae09101b31a6c7fd"
   dependencies:
-    camelcase-css "^1.0.1"
     css-selector-tokenizer "^0.7.0"
     deindent "^0.1.0"
-    kebab-case "^1.0.0"
+    enhanced-resolve "^3.4.1"
     lodash.clonedeep "^4.5.0"
-    murmurhash "0.0.2"
+    murmurhash "^0.0.2"
     postcss "^6.0.3"
     postcss-js "^1.0.0"
     postcss-nested "^2.0.2"
     postcss-safe-parser "^3.0.1"
     postcss-value-parser "^3.3.0"
-    stylis "^3.2.3"
 
 style-loader@~0.13.1:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.13.2.tgz#74533384cf698c7104c7951150b49717adc2f3bb"
   dependencies:
     loader-utils "^1.0.2"
-
-stylis@^3.2.3:
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.9.tgz#95c23da02d4389a2c5bab544a84abb3c13cc5d71"
 
 supports-color@3.1.2:
   version "3.1.2"


### PR DESCRIPTION
Upgraded to stylable-4.0.16, where the `runtime` entry point now has a proper .d.ts.

This saves users from having to install @types/node if they want to use wix-style-react (in the current setup of stylable).